### PR TITLE
feature: this module can now be built as a "dynamic module" with NGIN…

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,373 @@
 ngx_addon_name=ngx_http_lua_cache_module
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_lua_cache_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_lua_cache_module.c $ngx_addon_dir/src/ngx_http_lua_cache_control.c"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ngx_http_lua_cache_control.h"
+HTTP_LUA_CACHE_DEPS="$ngx_addon_dir/src/ngx_http_lua_cache_control.h"
+HTTP_LUA_CACHE_SRCS="$ngx_addon_dir/src/ngx_http_lua_cache_module.c $ngx_addon_dir/src/ngx_http_lua_cache_control.c"
+
+ngx_feature="Lua library"
+ngx_feature_libs="-llua -lm"
+ngx_feature_name=
+ngx_feature_run=no
+ngx_feature_incs="#include <lauxlib.h>"
+ngx_feature_path=
+ngx_feature_test="#if LUA_VERSION_NUM != 501
+#   error unsupported Lua language version
+#endif
+(void) luaL_newstate();"
+ngx_lua_opt_I=
+ngx_lua_opt_L=
+
+if [ -n "$LUAJIT_INC" -o -n "$LUAJIT_LIB" ]; then
+    # explicitly set LuaJIT paths
+
+    if [ "$NGX_PLATFORM" = win32 ]; then
+        ngx_feature="LuaJIT library in $LUAJIT_LIB and $LUAJIT_INC (win32)"
+        ngx_feature_path="$LUAJIT_INC"
+        ngx_lua_opt_I="-I$LUAJIT_INC"
+        ngx_lua_opt_L="-L$LUAJIT_LIB"
+
+        # ensure that our -I$LUAJIT_INC and -L$LUAJIT_LIB is at the first.
+        SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+        CC_TEST_FLAGS="$ngx_lua_opt_I $CC_TEST_FLAGS"
+        SAVED_NGX_TEST_LD_OPT="$NGX_TEST_LD_OPT"
+        NGX_TEST_LD_OPT="$ngx_lua_opt_L $NGX_TEST_LD_OPT"
+
+        # LuaJIT's win32 build uses the library file name lua51.dll.
+        ngx_feature_libs="$ngx_lua_opt_L -llua51"
+
+        . auto/feature
+
+        # clean up
+        CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+        NGX_TEST_LD_OPT="$SAVED_NGX_TEST_LD_OPT"
+    else
+
+        # attempt to link with -ldl, static linking on Linux requires it.
+        ngx_feature="LuaJIT library in $LUAJIT_LIB and $LUAJIT_INC (specified by the LUAJIT_LIB and LUAJIT_INC env, with -ldl)"
+        ngx_feature_path="$LUAJIT_INC"
+        ngx_lua_opt_I="-I$LUAJIT_INC"
+        ngx_lua_opt_L="-L$LUAJIT_LIB"
+
+        # ensure that our -I$LUAJIT_INC and -L$LUAJIT_LIB is at the first.
+        SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+        CC_TEST_FLAGS="$ngx_lua_opt_I $CC_TEST_FLAGS"
+        SAVED_NGX_TEST_LD_OPT="$NGX_TEST_LD_OPT"
+        NGX_TEST_LD_OPT="$ngx_lua_opt_L $NGX_TEST_LD_OPT"
+
+        if [ $NGX_RPATH = YES ]; then
+            ngx_feature_libs="-R$LUAJIT_LIB $ngx_lua_opt_L -lluajit-5.1 -lm -ldl"
+        else
+            ngx_feature_libs="$ngx_lua_opt_L -lluajit-5.1 -lm -ldl"
+        fi
+
+        . auto/feature
+
+        # clean up
+        CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+        NGX_TEST_LD_OPT="$SAVED_NGX_TEST_LD_OPT"
+
+        if [ $ngx_found = no ]; then
+            # retry without -ldl
+            ngx_feature="LuaJIT library in $LUAJIT_LIB and $LUAJIT_INC (specified by the LUAJIT_LIB and LUAJIT_INC env)"
+            ngx_feature_path="$LUAJIT_INC"
+            ngx_lua_opt_I="-I$LUAJIT_INC"
+            ngx_lua_opt_L="-L$LUAJIT_LIB"
+
+            # ensure that our -I$LUAJIT_INC and -L$LUAJIT_LIB is at the first.
+            SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+            CC_TEST_FLAGS="$ngx_lua_opt_I $CC_TEST_FLAGS"
+            SAVED_NGX_TEST_LD_OPT="$NGX_TEST_LD_OPT"
+            NGX_TEST_LD_OPT="$ngx_lua_opt_L $NGX_TEST_LD_OPT"
+
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R$LUAJIT_LIB $ngx_lua_opt_L -lluajit-5.1 -lm"
+            else
+                ngx_feature_libs="$ngx_lua_opt_L -lluajit-5.1 -lm"
+            fi
+
+            . auto/feature
+
+            # clean up
+            CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+            NGX_TEST_LD_OPT="$SAVED_NGX_TEST_LD_OPT"
+        fi
+    fi
+
+    if [ $ngx_found = no ]; then
+        cat << END
+        $0: error: ngx_http_lua_module requires the Lua or LuaJIT library and LUAJIT_LIB is defined as $LUAJIT_LIB and LUAJIT_INC (path for lua.h) $LUAJIT_INC, but we cannot find LuaJIT there.
+END
+        exit 1
+    fi
+
+    case "$NGX_PLATFORM" in
+        Darwin:*)
+            case "$NGX_MACHINE" in
+                amd64 | x86_64 | i386)
+                    echo "adding extra linking options needed by LuaJIT"
+                    ngx_feature_libs="$ngx_feature_libs -pagezero_size 10000 -image_base 100000000"
+                ;;
+
+                *)
+                ;;
+            esac
+        ;;
+
+        *)
+        ;;
+    esac
+else
+    if [ -n "$LUA_INC" -o -n "$LUA_LIB" ]; then
+        # explicitly set Lua paths
+        ngx_feature="Lua library in $LUA_LIB and $LUA_INC (specified by the LUA_LIB and LUA_INC env)"
+        ngx_feature_path="$LUA_INC"
+        ngx_lua_opt_I="-I$LUA_INC"
+        ngx_lua_opt_L="-L$LUA_LIB"
+
+        # ensure that our -I$LUA_INC and -L$LUA_LIB is at the first.
+        SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+        CC_TEST_FLAGS="$ngx_lua_opt_I $CC_TEST_FLAGS"
+        SAVED_NGX_TEST_LD_OPT="$NGX_TEST_LD_OPT"
+        NGX_TEST_LD_OPT="$ngx_lua_opt_L $NGX_TEST_LD_OPT"
+
+        if [ $NGX_RPATH = YES ]; then
+            ngx_feature_libs="-R$LUA_LIB $ngx_lua_opt_L -llua -lm -ldl"
+        else
+            ngx_feature_libs="$ngx_lua_opt_L -llua -lm -ldl"
+        fi
+
+        . auto/feature
+
+        # clean up
+        CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+        NGX_TEST_LD_OPT="$SAVED_NGX_TEST_LD_OPT"
+
+        if [ $ngx_found = no ]; then
+            # retry without -ldl
+
+            ngx_feature_path="$LUA_INC"
+            ngx_lua_opt_I="-I$LUA_INC"
+            ngx_lua_opt_L="-L$LUA_LIB"
+
+            # ensure that our -I$LUA_INC and -L$LUA_LIB is at the first.
+            SAVED_CC_TEST_FLAGS="$CC_TEST_FLAGS"
+            CC_TEST_FLAGS="$ngx_lua_opt_I $CC_TEST_FLAGS"
+            SAVED_NGX_TEST_LD_OPT="$NGX_TEST_LD_OPT"
+            NGX_TEST_LD_OPT="$ngx_lua_opt_L $NGX_TEST_LD_OPT"
+
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R$LUA_LIB $ngx_lua_opt_L -llua -lm"
+            else
+                ngx_feature_libs="$ngx_lua_opt_L -llua -lm"
+            fi
+
+            . auto/feature
+
+            # clean up
+            CC_TEST_FLAGS="$SAVED_CC_TEST_FLAGS"
+            NGX_TEST_LD_OPT="$SAVED_NGX_TEST_LD_OPT"
+        fi
+
+        if [ $ngx_found = no ]; then
+            cat << END
+            $0: error: ngx_http_lua_module requires the Lua or LuaJIT library and LUA_LIB is defined as $LUA_LIB and LUA_INC (path for lua.h) is $LUA_INC, but we cannot find standard Lua there.
+END
+            exit 1
+        fi
+    else
+        # auto-discovery
+        ngx_feature="Lua library"
+        ngx_feature_libs="-llua -lm"
+        . auto/feature
+
+        if [ $ngx_found = no ]; then
+            # OpenBSD-5.2
+            ngx_feature="Lua library in /usr/local/"
+            ngx_feature_path="/usr/local/include/lua-5.1"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/local/lib -L/usr/local/lib -llua -lm"
+            else
+                ngx_feature_libs="-L/usr/local/lib -llua5.1 -lm"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # OpenBSD < 5.2
+            ngx_feature="Lua library in /usr/local/"
+            ngx_feature_path="/usr/local/include"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/local/lib -L/usr/local/lib -llua -lm"
+            else
+                ngx_feature_libs="-L/usr/local/lib -llua -lm"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # NetBSD
+            ngx_feature="Lua library in /usr/pkg/"
+            ngx_feature_path="/usr/pkg/include/"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/pkg/lib -L/usr/pkg/lib -lm -llua"
+            else
+                ngx_feature_libs="-L/usr/pkg/lib -lm -llua"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # MacPorts
+            ngx_feature="Lua library in /opt/local/"
+            ngx_feature_path="/opt/local/include"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/opt/local/lib -L/opt/local/lib -lm -llua"
+            else
+                ngx_feature_libs="-L/opt/local/lib -lm -llua"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # FreeBSD
+            ngx_feature="Lua library in /usr/local/*/lua51/"
+            ngx_feature_path="/usr/local/include/lua51"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/local/lib/lua51 -L/usr/local/lib/lua51 -llua -lm"
+            else
+                ngx_feature_libs="-L/usr/local/lib/lua51 -llua -lm"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # Debian
+            ngx_feature="Lua library in /usr/"
+            ngx_feature_path="/usr/include/lua5.1"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/lib -L/usr/lib -lm -llua5.1"
+            else
+                ngx_feature_libs="-L/usr/lib -lm -llua5.1"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # FreeBSD with luajit-2.0 from ports collection
+            ngx_feature="LuaJIT library in /usr/local/"
+            ngx_feature_path="/usr/local/include/luajit-2.0"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/local/lib -L/usr/local/lib -lluajit-5.1 -lm"
+            else
+                ngx_feature_libs="-L/usr/local/lib -lluajit-5.1 -lm"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # Gentoo with LuaJIT-2.0, try with -ldl
+            ngx_feature="LuaJIT library in /usr/"
+            ngx_feature_path="/usr/include/luajit-2.0"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/lib -L/usr/lib -lm -lluajit-5.1 -ldl"
+            else
+                ngx_feature_libs="-L/usr/lib -lm -lluajit-5.1 -ldl"
+            fi
+            . auto/feature
+        fi
+
+        if [ $ngx_found = no ]; then
+            # Gentoo with LuaJIT 2.0
+            ngx_feature="LuaJIT library in /usr/"
+            ngx_feature_path="/usr/include/luajit-2.0"
+            if [ $NGX_RPATH = YES ]; then
+                ngx_feature_libs="-R/usr/lib -L/usr/lib -lm -lluajit-5.1"
+            else
+                ngx_feature_libs="-L/usr/lib -lm -lluajit-5.1"
+            fi
+            . auto/feature
+        fi
+    fi
+fi
+
+ngx_module_incs=
+ngx_module_libs=
+
+if [ $ngx_found = yes ]; then
+    # this is a hack to persuade nginx's build system to favor
+    # the paths set by our user environments:
+    CFLAGS="$ngx_lua_opt_I $CFLAGS"
+    NGX_LD_OPT="$ngx_lua_opt_L $NGX_LD_OPT"
+
+    ngx_module_incs="$ngx_module_incs $ngx_feature_path"
+    ngx_module_libs="$ngx_module_libs $ngx_feature_libs"
+else
+ cat << END
+ $0: error: ngx_http_lua_module requires the Lua library.
+END
+ exit 1
+fi
+
+CFLAGS="$CFLAGS -DNDK_SET_VAR"
+
+ngx_feature="export symbols by default (-E)"
+ngx_feature_libs="-Wl,-E"
+ngx_feature_name=
+ngx_feature_run=no
+ngx_feature_incs="#include <stdio.h>"
+ngx_feature_path=
+ngx_feature_test='printf("hello");'
+
+. auto/feature
+
+if [ $ngx_found = yes ]; then
+    CORE_LIBS="-Wl,-E $CORE_LIBS"
+fi
+
+# for Cygwin
+ngx_feature="export symbols by default (--export-all-symbols)"
+ngx_feature_libs="-Wl,--export-all-symbols"
+ngx_feature_name=
+ngx_feature_run=no
+ngx_feature_incs="#include <stdio.h>"
+ngx_feature_path=
+ngx_feature_test='printf("hello");'
+
+. auto/feature
+
+if [ $ngx_found = yes ]; then
+    CORE_LIBS="-Wl,--export-all-symbols $CORE_LIBS"
+fi
+
+NGX_DTRACE_PROVIDERS="$NGX_DTRACE_PROVIDERS $ngx_addon_dir/dtrace/ngx_lua_provider.d"
+NGX_TAPSET_SRCS="$NGX_TAPSET_SRCS $ngx_addon_dir/tapset/ngx_lua.stp"
+
+USE_MD5=YES
+USE_SHA1=YES
+
+CORE_INCS="$CORE_INCS $ngx_addon_dir/src/api"
+
+ngx_feature="SO_PASSCRED"
+ngx_feature_libs=
+ngx_feature_name="NGX_HTTP_LUA_HAVE_SO_PASSCRED"
+ngx_feature_run=no
+ngx_feature_incs="#include <sys/types.h>
+#include <sys/socket.h>"
+ngx_feature_path=
+ngx_feature_test='setsockopt(1, SOL_SOCKET, SO_PASSCRED, NULL, 0);'
+
+. auto/feature
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP_AUX_FILTER
+    ngx_module_name=$ngx_addon_name
+    ngx_module_deps="$HTTP_LUA_CACHE_DEPS"
+    ngx_module_srcs="$HTTP_LUA_CACHE_SRCS"
+
+    . auto/module
+else
+    HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES $ngx_addon_name"
+    NGX_ADDON_DEPS="$NGX_ADDON_DEPS $HTTP_LUA_CACHE_DEPS"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $HTTP_LUA_CACHE_SRCS"
+
+    CORE_INCS="$CORE_INCS $ngx_module_incs"
+    CORE_LIBS="$CORE_LIBS $ngx_module_libs"
+fi


### PR DESCRIPTION
…X 1.9.11+ via the --add-dynamic-module=PATH option of ./configure.

I copied codes from the `config` file from
https://github.com/openresty/lua-nginx-module/commit/4f2954302ce642a6f17255cff294663aa6552d8d
and modified it for lua-upstream-cache-nginx-module.