### PR TITLE
Add support for dynamic modules

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,13 @@
 ngx_addon_name=ngx_http_lua_cache_module
-HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_lua_cache_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_lua_cache_module.c $ngx_addon_dir/src/ngx_http_lua_cache_control.c"
-NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ngx_http_lua_cache_control.h"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_name=ngx_http_lua_cache_module
+    ngx_module_srcs="$ngx_addon_dir/src/ngx_http_lua_cache_module.c $ngx_addon_dir/src/ngx_http_lua_cache_control.c"
+    ngx_module_deps="$ngx_addon_dir/src/ngx_http_lua_cache_control.h"
+
+    . auto/module
+else
+    HTTP_AUX_FILTER_MODULES="$HTTP_AUX_FILTER_MODULES ngx_http_lua_cache_module"
+    NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/src/ngx_http_lua_cache_module.c $ngx_addon_dir/src/ngx_http_lua_cache_control.c"
+    NGX_ADDON_DEPS="$NGX_ADDON_DEPS $ngx_addon_dir/src/ngx_http_lua_cache_control.h"
+fi


### PR DESCRIPTION
Made it possible for the module to be compiled into a dynamic module (without breaking current functionality), ie, into a .so file that can be loaded during runtime.

Ref: [Nginx Doc](https://www.nginx.com/resources/wiki/extending/converting/#compiling-dynamic)

Fixes: https://github.com/cloudflare/lua-upstream-cache-nginx-module/issues/6